### PR TITLE
Security Improvements

### DIFF
--- a/src/basecontext/main.go
+++ b/src/basecontext/main.go
@@ -41,7 +41,8 @@ func NewBaseContext() *BaseContext {
 
 func NewRootBaseContext() *BaseContext {
 	baseContext := &BaseContext{
-		ctx: context.Background(),
+		ctx:       context.Background(),
+		shouldLog: true,
 		authContext: &AuthorizationContext{
 			IsAuthorized: true,
 			AuthorizedBy: "RootAuthorization",

--- a/src/cmd/generate_security_key.go
+++ b/src/cmd/generate_security_key.go
@@ -9,9 +9,7 @@ import (
 	"github.com/cjlapao/common-go/helper"
 )
 
-func processGenerateSecurityKey() {
-	ctx := basecontext.NewRootBaseContext()
-
+func processGenerateSecurityKey(ctx basecontext.ApiContext) {
 	ctx.LogInfo("Generating security key")
 	filename := "private.key"
 

--- a/src/cmd/install.go
+++ b/src/cmd/install.go
@@ -9,9 +9,7 @@ import (
 	"github.com/cjlapao/common-go/helper"
 )
 
-func processInstall() {
-	ctx := basecontext.NewRootBaseContext()
-
+func processInstall(ctx basecontext.ApiContext) {
 	filePath := helper.GetFlagValue(constants.FILE_FLAG, "")
 	if filePath != "" {
 		if err := install.InstallService(ctx, filePath); err != nil {

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -14,23 +14,25 @@ func Process() {
 
 	switch command {
 	case constants.API_COMMAND:
-		processApi()
+		processApi(ctx)
 	case constants.GENERATE_SECURITY_KEY_COMMAND:
-		processGenerateSecurityKey()
+		processGenerateSecurityKey(ctx)
 	case constants.INSTALL_SERVICE_COMMAND:
-		processInstall()
+		processInstall(ctx)
 	case constants.UNINSTALL_SERVICE_COMMAND:
-		processUninstall()
+		processUninstall(ctx)
 	case constants.TEST_COMMAND:
-		processTestProviders()
+		processTestProviders(ctx)
 	case constants.VERSION_COMMAND:
 		processVersion()
 	case constants.HELP_COMMAND:
 		processHelp("")
 	case constants.CATALOG_COMMAND:
 		processCatalog(ctx)
+	case constants.UPDATE_ROOT_PASSWORD_COMMAND:
+		processRootPassword(ctx)
 	default:
-		processApi()
+		processApi(ctx)
 	}
 	os.Exit(0)
 }

--- a/src/cmd/root_password.go
+++ b/src/cmd/root_password.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/Parallels/pd-api-service/basecontext"
+	"github.com/Parallels/pd-api-service/constants"
+	"github.com/Parallels/pd-api-service/data"
+	"github.com/Parallels/pd-api-service/serviceprovider"
+	"github.com/cjlapao/common-go/helper"
+)
+
+func processRootPassword(ctx basecontext.ApiContext) {
+	ctx.LogInfo("Updating root password")
+	rootPassword := helper.GetFlagValue(constants.PASSWORD_FLAG, "")
+	if rootPassword != "" {
+		db := serviceprovider.Get().JsonDatabase
+		ctx.LogInfo("Database connection found, updating password")
+		_ = db.Connect(ctx)
+		if db != nil {
+			err := db.UpdateRootPassword(ctx, rootPassword)
+			if err != nil {
+				panic(err)
+			}
+			_ = db.Disconnect(ctx)
+		} else {
+			panic(data.ErrDatabaseNotConnected)
+		}
+	} else {
+		panic("No password provided")
+	}
+	ctx.LogInfo("Root password updated")
+
+	os.Exit(0)
+}

--- a/src/cmd/test_providers.go
+++ b/src/cmd/test_providers.go
@@ -9,8 +9,7 @@ import (
 	"github.com/cjlapao/common-go/helper"
 )
 
-func processTestProviders() {
-	ctx := basecontext.NewRootBaseContext()
+func processTestProviders(ctx basecontext.ApiContext) {
 	// Checking if we just want to test
 	if helper.GetFlagSwitch(constants.TEST_CATALOG_PROVIDERS_FLAG, false) {
 		if err := tests.TestCatalogProviders(ctx); err != nil {

--- a/src/cmd/uninstall.go
+++ b/src/cmd/uninstall.go
@@ -7,9 +7,7 @@ import (
 	"github.com/Parallels/pd-api-service/install"
 )
 
-func processUninstall() {
-	ctx := basecontext.NewRootBaseContext()
-
+func processUninstall(ctx basecontext.ApiContext) {
 	if err := install.UninstallService(ctx); err != nil {
 		ctx.LogError(err.Error())
 		os.Exit(1)

--- a/src/constants/main.go
+++ b/src/constants/main.go
@@ -64,6 +64,7 @@ const (
 	VERSION_COMMAND               = "version"
 	HELP_COMMAND                  = "help"
 	CATALOG_COMMAND               = "catalog"
+	UPDATE_ROOT_PASSWORD_COMMAND  = "update-root-pass"
 
 	TEST_FLAG                       = "test"
 	TEST_CATALOG_PROVIDERS_FLAG     = "catalog-providers"
@@ -72,6 +73,7 @@ const (
 	FILE_FLAG                       = "file"
 	MODE_FLAG                       = "mode"
 	HELP_FLAG                       = "help"
+	PASSWORD_FLAG                   = "password"
 	USE_ORCHESTRATOR_RESOURCES_FLAG = "use-orchestrator-resources"
 )
 

--- a/src/controllers/authorization.go
+++ b/src/controllers/authorization.go
@@ -82,9 +82,7 @@ func GetTokenHandler() restapi.ControllerHandler {
 			return
 		}
 
-		// Hash the password with SHA-256
-		hashedPassword := helpers.Sha256Hash(request.Password)
-		if hashedPassword != user.Password {
+		if err := helpers.BcryptCompare(request.Password, user.ID, user.Password); err != nil {
 			ReturnApiError(ctx, w, models.ApiErrorResponse{
 				Message: "Invalid Password",
 				Code:    http.StatusUnauthorized,

--- a/src/data/api_key.go
+++ b/src/data/api_key.go
@@ -59,7 +59,11 @@ func (j *JsonDatabase) CreateApiKey(ctx basecontext.ApiContext, apiKey models.Ap
 	}
 
 	// Hash the password with SHA-256
-	apiKey.Secret = helpers.Sha256Hash(apiKey.Secret)
+	hashSecret, err := helpers.BcryptHash(apiKey.Secret, apiKey.ID)
+	if err != nil {
+		return nil, err
+	}
+	apiKey.Secret = hashSecret
 	apiKey.UpdatedAt = helpers.GetUtcCurrentDateTime()
 	apiKey.CreatedAt = helpers.GetUtcCurrentDateTime()
 	j.data.ApiKeys = append(j.data.ApiKeys, apiKey)

--- a/src/data/users.go
+++ b/src/data/users.go
@@ -128,7 +128,11 @@ func (j *JsonDatabase) CreateUser(ctx basecontext.ApiContext, user models.User) 
 	}
 
 	// Hash the password with SHA-256
-	user.Password = helpers.Sha256Hash(user.Password)
+	hashedPassword, err := helpers.BcryptHash(user.Password, user.ID)
+	if err != nil {
+		return nil, err
+	}
+	user.Password = hashedPassword
 
 	user.UpdatedAt = helpers.GetUtcCurrentDateTime()
 	user.CreatedAt = helpers.GetUtcCurrentDateTime()
@@ -155,7 +159,11 @@ func (j *JsonDatabase) UpdateUser(ctx basecontext.ApiContext, key models.User) e
 				j.data.Users[i].Name = key.Name
 			}
 			if key.Password != "" {
-				j.data.Users[i].Password = helpers.Sha256Hash(key.Password)
+				hashedPassword, err := helpers.BcryptHash(key.Password, key.ID)
+				if err != nil {
+					return err
+				}
+				j.data.Users[i].Password = hashedPassword
 			}
 
 			j.data.Users[i].UpdatedAt = helpers.GetUtcCurrentDateTime()
@@ -176,7 +184,11 @@ func (j *JsonDatabase) UpdateRootPassword(ctx basecontext.ApiContext, newPasswor
 
 	for i, user := range j.data.Users {
 		if user.Email == "root@localhost" {
-			j.data.Users[i].Password = helpers.Sha256Hash(newPassword)
+			hashedPassword, err := helpers.BcryptHash(newPassword, user.ID)
+			if err != nil {
+				return err
+			}
+			j.data.Users[i].Password = hashedPassword
 			j.data.Users[i].UpdatedAt = helpers.GetUtcCurrentDateTime()
 			if err := j.Save(ctx); err != nil {
 				return err

--- a/src/helpers/strings_test.go
+++ b/src/helpers/strings_test.go
@@ -1,0 +1,22 @@
+package helpers
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestBcryptHash(t *testing.T) {
+	input := "password"
+	salt := "somesalt"
+
+	hashedPwd, err := BcryptHash(input, salt)
+	if err != nil {
+		t.Errorf("Error hashing password: %v", err)
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(hashedPwd), []byte(input+salt))
+	if err != nil {
+		t.Errorf("Hashed password does not match input: %v", err)
+	}
+}

--- a/src/restapi/apikey_authorization_middleware.go
+++ b/src/restapi/apikey_authorization_middleware.go
@@ -69,8 +69,7 @@ func ApiKeyAuthorizationMiddlewareAdapter(roles []string, claims []string) Adapt
 				}
 			}
 			if isValid {
-				hashedSecret := helpers.Sha256Hash(apiKey.Value)
-				if dbApiKey.Secret != hashedSecret {
+				if err := helpers.BcryptCompare(apiKey.Value, dbApiKey.ID, dbApiKey.Secret); err != nil {
 					isValid = false
 					authError.ErrorDescription = "Api Key is not Valid"
 				}

--- a/src/serviceprovider/main.go
+++ b/src/serviceprovider/main.go
@@ -103,7 +103,16 @@ func InitCatalogServices(ctx basecontext.ApiContext) {
 	}
 
 	globalProvider.HardwareId = hid
-	globalProvider.HardwareSecret = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", key, hid)))
+	secretKey := strings.ReplaceAll(key, "-", "")
+	secretHid := strings.ReplaceAll(hid, "-", "")
+	if len(secretKey) > 12 {
+		secretKey = secretKey[:12]
+	}
+	if len(secretHid) > 12 {
+		secretHid = secretHid[:12]
+	}
+
+	globalProvider.HardwareSecret = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s%s", secretKey, secretHid)))
 	if systemHardwareInfo, err := globalProvider.System.GetHardwareInfo(ctx); err == nil {
 		globalProvider.SystemHardwareInfo = systemHardwareInfo
 	}


### PR DESCRIPTION
# Description

- moved from sha256 hashing to bcrypt hashing
- added salt to the password hashing
- some small improvements in the cmd line interface

** Attention** This will break current users, including the superuser because the move for the bcrypt will break the current passwords of the users and API keys.
- For the Super User, you can use the environment variable *ROOT_PASSWORD* and set the new password. This will update the current hashing. For all other users, you will need to use the updated user and set the new password.
- For API Keys, the only way is to delete the key and recreate it. This is because the API Keys do not allow the secret to be updated

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly